### PR TITLE
Add visitor to offset parameter annotations

### DIFF
--- a/src/main/java/net/fabricmc/stitch/commands/CommandMergeJar.java
+++ b/src/main/java/net/fabricmc/stitch/commands/CommandMergeJar.java
@@ -33,7 +33,7 @@ public class CommandMergeJar extends Command {
 
     @Override
     public String getHelpString() {
-        return "<client-jar> <server-jar> <output> [--removeSnowman]";
+        return "<client-jar> <server-jar> <output> [--removeSnowman] [--syntheticparams]";
     }
 
     @Override
@@ -46,13 +46,16 @@ public class CommandMergeJar extends Command {
         File in1f = new File(args[0]);
         File in2f = new File(args[1]);
         File outf = new File(args[2]);
-        boolean removeSnowman = false;
+        boolean removeSnowman = false, syntheticParams = false;
 
         for (int i = 3; i < args.length; i++) {
             if (args[i].startsWith("--")) {
                 switch (args[i].substring(2).toLowerCase(Locale.ROOT)) {
                     case "removesnowman":
                         removeSnowman = true;
+                        break;
+                    case "syntheticparams":
+                        syntheticParams = true;
                         break;
                 }
             }
@@ -75,6 +78,10 @@ public class CommandMergeJar extends Command {
                 merger.enableSnowmanRemoval();
             }
 
+            if (syntheticParams) {
+                merger.enableSyntheticParamsOffset();
+            }
+
             try {
                 System.out.println("Merging...");
 
@@ -86,7 +93,7 @@ public class CommandMergeJar extends Command {
             } finally {
                 merger.close();
             }
-       } catch (IOException e) {
+        } catch (IOException e) {
             e.printStackTrace();
         }
     }

--- a/src/main/java/net/fabricmc/stitch/merge/JarMerger.java
+++ b/src/main/java/net/fabricmc/stitch/merge/JarMerger.java
@@ -18,6 +18,7 @@ package net.fabricmc.stitch.merge;
 
 import net.fabricmc.stitch.util.SnowmanClassVisitor;
 import net.fabricmc.stitch.util.StitchUtil;
+import net.fabricmc.stitch.util.SyntheticParameterClassVisitor;
 import org.objectweb.asm.ClassReader;
 import org.objectweb.asm.ClassVisitor;
 import org.objectweb.asm.ClassWriter;
@@ -31,7 +32,6 @@ import java.nio.file.attribute.FileTime;
 import java.util.*;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
-import java.util.concurrent.ForkJoinPool;
 import java.util.concurrent.TimeUnit;
 import java.util.jar.JarEntry;
 import java.util.jar.JarInputStream;
@@ -57,6 +57,7 @@ public class JarMerger {
     private final Map<String, Entry> entriesClient, entriesServer;
     private final Set<String> entriesAll;
     private boolean removeSnowmen = false;
+    private boolean offsetSyntheticsParams = false;
 
     public JarMerger(JarInputStream inputClient, JarInputStream inputServer, JarOutputStream output) {
         this.inputClient = inputClient;
@@ -79,6 +80,10 @@ public class JarMerger {
 
     public void enableSnowmanRemoval() {
         removeSnowmen = true;
+    }
+
+    public void enableSyntheticParamsOffset() {
+        offsetSyntheticsParams = true;
     }
 
     public void close() throws IOException {
@@ -173,6 +178,10 @@ public class JarMerger {
 
                     if (removeSnowmen) {
                         visitor = new SnowmanClassVisitor(Opcodes.ASM7, visitor);
+                    }
+
+                    if (offsetSyntheticsParams) {
+                        visitor = new SyntheticParameterClassVisitor(Opcodes.ASM7, visitor);
                     }
 
                     if (visitor != writer) {

--- a/src/main/java/net/fabricmc/stitch/util/SyntheticParameterClassVisitor.java
+++ b/src/main/java/net/fabricmc/stitch/util/SyntheticParameterClassVisitor.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright (c) 2016, 2017, 2018 Adrian Siekierka
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.fabricmc.stitch.util;
+
+import org.objectweb.asm.*;
+import org.objectweb.asm.signature.SignatureReader;
+import org.objectweb.asm.signature.SignatureVisitor;
+
+/**
+ * ProGuard has a bug where parameter annotations are applied incorrectly in the presence of
+ * synthetic arguments. This causes javac to balk when trying to load affected classes.
+ *
+ * We compute the offset between a method's descriptor and signature to determine the number
+ * of synthetic arguments, then subtract that from each parameter annotation.
+ */
+public class SyntheticParameterClassVisitor extends ClassVisitor {
+    static class SyntheticMethodVisitor extends MethodVisitor {
+        private final String descriptor;
+        private final String signature;
+        private int offset = -1;
+
+        SyntheticMethodVisitor(int api, String descriptor, String signature, MethodVisitor methodVisitor) {
+            super(api, methodVisitor);
+            this.descriptor = descriptor;
+            this.signature = signature;
+        }
+
+        private int getOffset() {
+            if (offset >= 0) return offset;
+
+            ArgumentSignatureCounter signatureCounter = new ArgumentSignatureCounter();
+            new SignatureReader(signature).accept(signatureCounter);
+            int parameters = Type.getArgumentTypes(descriptor).length;
+
+            return this.offset = parameters - signatureCounter.count;
+        }
+
+        @Override
+        public AnnotationVisitor visitParameterAnnotation(int parameter, String descriptor, boolean visible) {
+            return super.visitParameterAnnotation(parameter - getOffset(), descriptor, visible);
+        }
+
+        @Override
+        public void visitAnnotableParameterCount(int parameterCount, boolean visible) {
+            super.visitAnnotableParameterCount(parameterCount - getOffset(), visible);
+        }
+    }
+
+    private boolean skip;
+
+    public SyntheticParameterClassVisitor(int api, ClassVisitor cv) {
+        super(api, cv);
+    }
+
+    @Override
+    public void visit(int version, int access, String name, String signature, String superName, String[] interfaces) {
+        skip = (access & Opcodes.ACC_ENUM) == 0;
+        super.visit(version, access, name, signature, superName, interfaces);
+    }
+
+    @Override
+    public MethodVisitor visitMethod(
+        final int access,
+        final String name,
+        final String descriptor,
+        final String signature,
+        final String[] exceptions) {
+        MethodVisitor mv = super.visitMethod(access, name, descriptor, signature, exceptions);
+        return signature == null || mv == null || skip
+            ? mv : new SyntheticMethodVisitor(api, descriptor, signature, mv);
+    }
+
+    private static final class ArgumentSignatureCounter extends SignatureVisitor {
+        int count;
+
+        ArgumentSignatureCounter() {
+            super(Opcodes.ASM7);
+        }
+
+        @Override
+        public SignatureVisitor visitParameterType() {
+            count++;
+            return super.visitParameterType();
+        }
+    }
+}


### PR DESCRIPTION
As discussed elsewhere, this rewrites the parameter annotation metadata so that synthetic arguments are skipped. This allows you to use `TextFormat` (which I believe is the only affected class).

I've left this as disabled by default for now, though am happy to change that if preferred.