### PR TITLE
Check to see if the class is mostly mapped, currently only checks fields.

### DIFF
--- a/src/main/java/net/fabricmc/stitch/commands/GenState.java
+++ b/src/main/java/net/fabricmc/stitch/commands/GenState.java
@@ -111,7 +111,7 @@ class GenState {
 
     @Nullable
     private String getFieldName(ClassStorage storage, JarClassEntry c, JarFieldEntry f) {
-        if (!isMappedField(storage, c, f) || !isMostlyMappedClass(storage, c, f)) {
+        if (!isMappedField(storage, c, f) || isMostlyMappedClass(storage, c, f)) {
             return null;
         }
 

--- a/src/main/java/net/fabricmc/stitch/commands/GenState.java
+++ b/src/main/java/net/fabricmc/stitch/commands/GenState.java
@@ -96,9 +96,22 @@ class GenState {
         return (m.getName().length() <= 2 || (m.getName().length() == 3 && m.getName().charAt(2) == '_')) && m.getName().charAt(0) != '<' && m.isSource(storage, c);
     }
 
+    //Checks to see if most of the fields in the class are mapped, if so we **assume** that this field can be skipped
+    private static boolean isMostlyMappedClass(ClassStorage storage, JarClassEntry c, AbstractJarEntry e){
+	    long fields = c.getFields().size();
+    	long debofFields = c.getFields().stream()
+		    .filter(entry -> !isMappedField(storage, c, entry))
+		    .count();
+	    boolean skip = fields > 3 && (((double)fields - (double)debofFields) / (double)fields) < 0.15;
+    	if(skip){
+		    System.out.println(String.format("Skipping mapping in: %s.%s (%d/%d)", c.getName(), e.getName(), fields, debofFields));
+	    }
+    	return !skip;
+    }
+
     @Nullable
     private String getFieldName(ClassStorage storage, JarClassEntry c, JarFieldEntry f) {
-        if (!isMappedField(storage, c, f)) {
+        if (!isMappedField(storage, c, f) || isMostlyMappedClass(storage, c, f)) {
             return null;
         }
 

--- a/src/main/java/net/fabricmc/stitch/commands/GenState.java
+++ b/src/main/java/net/fabricmc/stitch/commands/GenState.java
@@ -106,12 +106,12 @@ class GenState {
     	if(skip){
 		    System.out.println(String.format("Skipping mapping in: %s.%s (%d/%d)", c.getName(), e.getName(), fields, debofFields));
 	    }
-    	return !skip;
+    	return skip;
     }
 
     @Nullable
     private String getFieldName(ClassStorage storage, JarClassEntry c, JarFieldEntry f) {
-        if (!isMappedField(storage, c, f) || isMostlyMappedClass(storage, c, f)) {
+        if (!isMappedField(storage, c, f) || !isMostlyMappedClass(storage, c, f)) {
             return null;
         }
 


### PR DESCRIPTION
Output from 19w12a:

```
Skipping mapping in: cvb.x (15/13)
Skipping mapping in: cvb.y (15/13)
```