### PR TITLE
Move all weave stuff to stitch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,17 @@
+/.idea
+
+/work
+/tools
+/build
+/.gradle
+*.log
+*.reject
+/run/
+
+*.iml
+*.ipr
+*.iws
+*.ini
+/out
+/classes
+/test

--- a/src/main/java/net/fabricmc/stitch/Command.java
+++ b/src/main/java/net/fabricmc/stitch/Command.java
@@ -19,7 +19,7 @@ package net.fabricmc.stitch;
 public abstract class Command {
     public final String name;
 
-    public Command(String name) {
+    protected Command(String name) {
         this.name = name;
     }
 

--- a/src/main/java/net/fabricmc/stitch/Main.java
+++ b/src/main/java/net/fabricmc/stitch/Main.java
@@ -17,6 +17,8 @@
 package net.fabricmc.stitch;
 
 import net.fabricmc.stitch.commands.*;
+import net.fabricmc.stitch.enigma.CommandFindMappingErrors;
+import net.fabricmc.stitch.enigma.CommandTinyify;
 
 import java.util.Map;
 import java.util.TreeMap;
@@ -38,6 +40,19 @@ public class Main {
         addCommand(new CommandProposeFieldNames());
         addCommand(new CommandRewriteIntermediary());
         addCommand(new CommandUpdateIntermediary());
+
+        boolean enigmaPresent;
+        try {
+            Class.forName("cuchaz.enigma.translation.representation.entry.Entry");
+            enigmaPresent = true;
+        } catch (ClassNotFoundException e) {
+            enigmaPresent = false;
+        }
+
+        if (enigmaPresent) {
+            addCommand(new CommandFindMappingErrors());
+            addCommand(new CommandTinyify());
+        }
     }
 
     public static void main(String[] args) {

--- a/src/main/java/net/fabricmc/stitch/enigma/CommandFindMappingErrors.java
+++ b/src/main/java/net/fabricmc/stitch/enigma/CommandFindMappingErrors.java
@@ -1,0 +1,156 @@
+/*
+ * Copyright (c) 2016, 2017, 2018 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.fabricmc.stitch.enigma;
+
+import cuchaz.enigma.Deobfuscator;
+import cuchaz.enigma.ProgressListener;
+import cuchaz.enigma.analysis.EntryReference;
+import cuchaz.enigma.analysis.index.EntryIndex;
+import cuchaz.enigma.analysis.index.InheritanceIndex;
+import cuchaz.enigma.analysis.index.JarIndex;
+import cuchaz.enigma.analysis.index.ReferenceIndex;
+import cuchaz.enigma.translation.mapping.EntryMapping;
+import cuchaz.enigma.translation.mapping.EntryRemapper;
+import cuchaz.enigma.translation.mapping.serde.MappingFormat;
+import cuchaz.enigma.translation.mapping.tree.EntryTree;
+import cuchaz.enigma.translation.representation.AccessFlags;
+import cuchaz.enigma.translation.representation.entry.ClassEntry;
+import cuchaz.enigma.translation.representation.entry.FieldEntry;
+import cuchaz.enigma.translation.representation.entry.MethodDefEntry;
+import cuchaz.enigma.translation.representation.entry.MethodEntry;
+import net.fabricmc.stitch.Command;
+
+import java.io.File;
+import java.util.*;
+import java.util.jar.JarFile;
+
+public class CommandFindMappingErrors extends Command {
+	public CommandFindMappingErrors() {
+		super("findMappingErrors");
+	}
+
+	@Override
+	public String getHelpString() {
+		return "<obf jar> <mappings> [boolean: fail-fast]";
+	}
+
+	@Override
+	public boolean isArgumentCountValid(int count) {
+		return count == 2 || count == 3;
+	}
+
+	private void addError(NavigableMap<String, Set<String>> errorStrings, String error, String cause) {
+		if (!errorStrings.containsKey(error)) {
+			errorStrings.put(error, new HashSet<>());
+		}
+		errorStrings.get(error).add(cause);
+	}
+
+	private boolean isRefValid(AccessFlags entryAcc, EntryReference ref, Deobfuscator deobfuscator) {
+		EntryReference refDeobf = deobfuscator.getMapper().deobfuscate(ref);
+		String packageCtx = refDeobf.context.getContainingClass().getPackageName();
+		String packageEntry = refDeobf.entry.getContainingClass().getPackageName();
+		boolean samePackage = (packageCtx == null && packageEntry == null) || (packageCtx != null && packageCtx.equals(packageEntry));
+		if (samePackage) {
+			return true;
+		} else if (entryAcc.isProtected()) {
+			// TODO: Is this valid?
+			InheritanceIndex inheritanceIndex = deobfuscator.getJarIndex().getInheritanceIndex();
+
+			for (ClassEntry outerClass : getOuterClasses(ref.context.getContainingClass())) {
+				Set<ClassEntry> callerAncestors = inheritanceIndex.getAncestors(outerClass);
+				if (callerAncestors.contains(ref.entry.getContainingClass())) {
+					return true;
+				}
+			}
+		}
+
+		return false;
+	}
+
+	private Collection<ClassEntry> getOuterClasses(ClassEntry entry) {
+		Collection<ClassEntry> outerClasses = new ArrayList<>();
+
+		ClassEntry currentEntry = entry;
+		while (currentEntry != null) {
+			outerClasses.add(currentEntry);
+			currentEntry = currentEntry.getOuterClass();
+		}
+
+		return outerClasses;
+	}
+
+	@Override
+	public void run(String[] args) throws Exception {
+		File fileJarIn = new File(args[0]);
+		File fileMappings = new File(args[1]);
+
+		boolean failFast = args.length == 3 && Boolean.valueOf(args[2]);
+
+		System.out.println("Reading JAR...");
+		Deobfuscator deobfuscator = new Deobfuscator(new JarFile(fileJarIn));
+		System.out.println("Reading mappings...");
+
+		MappingFormat format = fileMappings.isDirectory() ? MappingFormat.ENIGMA_DIRECTORY : MappingFormat.ENIGMA_FILE;
+		EntryTree<EntryMapping> mappings = format.read(fileMappings.toPath(), ProgressListener.VOID);
+		deobfuscator.setMappings(mappings);
+
+		JarIndex idx = deobfuscator.getJarIndex();
+		EntryIndex entryIndex = idx.getEntryIndex();
+		ReferenceIndex referenceIndex = idx.getReferenceIndex();
+
+		EntryRemapper mapper = deobfuscator.getMapper();
+
+		NavigableMap<String, Set<String>> errorStrings = new TreeMap<>();
+
+		for (FieldEntry entry : entryIndex.getFields()) {
+			AccessFlags entryAcc = entryIndex.getFieldAccess(entry);
+			if (!entryAcc.isPublic() && !entryAcc.isPrivate()) {
+				for (EntryReference<FieldEntry, MethodDefEntry> ref : referenceIndex.getReferencesToField(entry)) {
+					boolean valid = isRefValid(entryAcc, ref, deobfuscator);
+
+					if (!valid) {
+						EntryReference<FieldEntry, MethodDefEntry> refDeobf = mapper.deobfuscate(ref);
+						addError(errorStrings, "ERROR: Must be in one package: " + refDeobf.context.getContainingClass() + " and " + refDeobf.entry.getContainingClass(), "field " + refDeobf.entry.getName());
+					}
+				}
+			}
+		}
+
+		for (MethodEntry entry : entryIndex.getMethods()) {
+			AccessFlags entryAcc = entryIndex.getMethodAccess(entry);
+			if (!entryAcc.isPublic() && !entryAcc.isPrivate()) {
+				for (EntryReference<MethodEntry, MethodDefEntry> ref : referenceIndex.getReferencesToMethod(entry)) {
+					boolean valid = isRefValid(entryAcc, ref, deobfuscator);
+
+					if (!valid) {
+						EntryReference<MethodEntry, MethodDefEntry> refDeobf = mapper.deobfuscate(ref);
+						addError(errorStrings, "ERROR: Must be in one package: " + refDeobf.context.getContainingClass() + " and " + refDeobf.entry.getContainingClass(), "method " + refDeobf.entry.getName());
+					}
+				}
+			}
+		}
+
+		for (String s : errorStrings.keySet()) {
+			System.out.println(s + " (" + String.join(", ", errorStrings.get(s)) + ")");
+		}
+
+		if (!errorStrings.isEmpty() && failFast) {
+			throw new RuntimeException("Detected mapping errors, aborting! See output above.");
+		}
+	}
+}

--- a/src/main/java/net/fabricmc/stitch/enigma/CommandFindMappingErrors.java
+++ b/src/main/java/net/fabricmc/stitch/enigma/CommandFindMappingErrors.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2017, 2018 FabricMC
+ * Copyright (c) 2016, 2017, 2018 Adrian Siekierka
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/fabricmc/stitch/enigma/CommandTinyify.java
+++ b/src/main/java/net/fabricmc/stitch/enigma/CommandTinyify.java
@@ -1,0 +1,189 @@
+/*
+ * Copyright (c) 2016, 2017, 2018 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.fabricmc.stitch.enigma;
+
+import com.google.common.collect.Lists;
+import cuchaz.enigma.ProgressListener;
+import cuchaz.enigma.analysis.ParsedJar;
+import cuchaz.enigma.analysis.index.JarIndex;
+import cuchaz.enigma.translation.MappingTranslator;
+import cuchaz.enigma.translation.Translator;
+import cuchaz.enigma.translation.mapping.EntryMapping;
+import cuchaz.enigma.translation.mapping.MappingDelta;
+import cuchaz.enigma.translation.mapping.MappingsChecker;
+import cuchaz.enigma.translation.mapping.VoidEntryResolver;
+import cuchaz.enigma.translation.mapping.serde.MappingFormat;
+import cuchaz.enigma.translation.mapping.serde.MappingsWriter;
+import cuchaz.enigma.translation.mapping.tree.EntryTree;
+import cuchaz.enigma.translation.mapping.tree.EntryTreeNode;
+import cuchaz.enigma.translation.representation.entry.ClassEntry;
+import cuchaz.enigma.translation.representation.entry.Entry;
+import cuchaz.enigma.translation.representation.entry.FieldEntry;
+import cuchaz.enigma.translation.representation.entry.MethodEntry;
+import net.fabricmc.stitch.Command;
+import net.fabricmc.stitch.util.StitchUtil;
+
+import java.io.*;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Comparator;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.jar.JarFile;
+
+public class CommandTinyify extends Command {
+
+	public CommandTinyify() {
+		super("tinyify");
+	}
+
+	@Override
+	public String getHelpString() {
+		return "<input-jar> <enigma-mappings> <output-tiny> [name-obf] [name-deobf]";
+	}
+
+	@Override
+	public boolean isArgumentCountValid(int count) {
+		return count >= 3 && count <= 5;
+	}
+
+	@Override
+	public void run(String[] args) throws Exception {
+		File injf = new File(args[0]);
+		File inf = new File(args[1]);
+		File outf = new File(args[2]);
+		String nameObf = args.length > 3 ? args[3] : "official";
+		String nameDeobf = args.length > 4 ? args[4] : "named";
+
+		if (!injf.exists() || !injf.isFile()) {
+			throw new FileNotFoundException("Input JAR could not be found!");
+		}
+
+		if (!inf.exists()) {
+			throw new FileNotFoundException("Enigma mappings could not be found!");
+		}
+
+		System.out.println("Reading JAR file...");
+
+		JarIndex index = JarIndex.empty();
+		index.indexJar(new ParsedJar(new JarFile(injf)), s -> {
+		});
+
+		System.out.println("Reading Enigma mappings...");
+		MappingFormat format = inf.isDirectory() ? MappingFormat.ENIGMA_DIRECTORY : MappingFormat.ENIGMA_FILE;
+		EntryTree<EntryMapping> mappings = format.read(inf.toPath(), ProgressListener.VOID);
+
+		MappingsChecker checker = new MappingsChecker(index, mappings);
+		checker.dropBrokenMappings(ProgressListener.VOID);
+
+		System.out.println("Writing Tiny mappings...");
+
+		MappingsWriter writer = new TinyMappingsWriter(nameObf, nameDeobf);
+		writer.write(mappings, MappingDelta.added(mappings), outf.toPath(), ProgressListener.VOID);
+	}
+
+	private static class TinyMappingsWriter implements MappingsWriter {
+
+		private static final String VERSION_CONSTANT = "v1";
+
+		// HACK: as of enigma 0.13.1, some fields seem to appear duplicated?
+		private final Set<String> writtenLines = new HashSet<>();
+		private final String nameObf;
+		private final String nameDeobf;
+
+		private TinyMappingsWriter(String nameObf, String nameDeobf) {
+			this.nameObf = nameObf;
+			this.nameDeobf = nameDeobf;
+		}
+
+		@Override
+		public void write(EntryTree<EntryMapping> mappings, MappingDelta<EntryMapping> delta, Path path, ProgressListener progress) {
+			try {
+				Files.deleteIfExists(path);
+				Files.createFile(path);
+			} catch (IOException e) {
+				e.printStackTrace();
+			}
+
+			try (BufferedWriter writer = Files.newBufferedWriter(path, StandardCharsets.UTF_8)) {
+				writeLine(writer, new String[]{VERSION_CONSTANT, nameObf, nameDeobf});
+
+				Lists.newArrayList(mappings).stream()
+						.map(EntryTreeNode::getEntry).sorted(Comparator.comparing(Object::toString))
+						.forEach(entry -> writeEntry(writer, mappings, entry));
+			} catch (IOException e) {
+				e.printStackTrace();
+			}
+		}
+
+		private void writeEntry(Writer writer, EntryTree<EntryMapping> mappings, Entry<?> entry) {
+			EntryTreeNode<EntryMapping> node = mappings.findNode(entry);
+			if (node == null) {
+				return;
+			}
+
+			Translator translator = new MappingTranslator(mappings, VoidEntryResolver.INSTANCE);
+
+			EntryMapping mapping = mappings.get(entry);
+			if (mapping != null && !entry.getName().equals(mapping.getTargetName())) {
+				if (entry instanceof ClassEntry) {
+					writeClass(writer, (ClassEntry) entry, translator);
+				} else if (entry instanceof FieldEntry) {
+					writeLine(writer, EnigmaUtil.serializeEntry(entry, true, mapping.getTargetName()));
+				} else if (entry instanceof MethodEntry) {
+					writeLine(writer, EnigmaUtil.serializeEntry(entry, true, mapping.getTargetName()));
+				}
+			}
+
+			writeChildren(writer, mappings, node);
+		}
+
+		private void writeChildren(Writer writer, EntryTree<EntryMapping> mappings, EntryTreeNode<EntryMapping> node) {
+			node.getChildren().stream()
+					.filter(e -> e instanceof FieldEntry).sorted()
+					.forEach(child -> writeEntry(writer, mappings, child));
+
+			node.getChildren().stream()
+					.filter(e -> e instanceof MethodEntry).sorted()
+					.forEach(child -> writeEntry(writer, mappings, child));
+
+			node.getChildren().stream()
+					.filter(e -> e instanceof ClassEntry).sorted()
+					.forEach(child -> writeEntry(writer, mappings, child));
+		}
+
+		private void writeClass(Writer writer, ClassEntry entry, Translator translator) {
+			ClassEntry translatedEntry = translator.translate(entry);
+
+			String obfClassName = StitchUtil.NONE_PREFIX_REMOVER.map(entry.getFullName());
+			String deobfClassName = StitchUtil.NONE_PREFIX_REMOVER.map(translatedEntry.getFullName());
+			writeLine(writer, new String[]{"CLASS", obfClassName, deobfClassName});
+		}
+
+		private void writeLine(Writer writer, String[] data) {
+			try {
+				String line = StitchUtil.TAB_JOINER.join(data) + "\n";
+				if (writtenLines.add(line)) {
+					writer.write(line);
+				}
+			} catch (IOException e) {
+				throw new RuntimeException(e);
+			}
+		}
+	}
+}

--- a/src/main/java/net/fabricmc/stitch/enigma/CommandTinyify.java
+++ b/src/main/java/net/fabricmc/stitch/enigma/CommandTinyify.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2017, 2018 FabricMC
+ * Copyright (c) 2016, 2017, 2018 Adrian Siekierka
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/fabricmc/stitch/enigma/EnigmaUtil.java
+++ b/src/main/java/net/fabricmc/stitch/enigma/EnigmaUtil.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 2016, 2017, 2018 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.fabricmc.stitch.enigma;
+
+import cuchaz.enigma.translation.representation.MethodDescriptor;
+import cuchaz.enigma.translation.representation.TypeDescriptor;
+import cuchaz.enigma.translation.representation.entry.ClassEntry;
+import cuchaz.enigma.translation.representation.entry.Entry;
+import cuchaz.enigma.translation.representation.entry.FieldEntry;
+import cuchaz.enigma.translation.representation.entry.MethodEntry;
+import net.fabricmc.stitch.util.StitchUtil;
+import org.checkerframework.checker.nullness.qual.Nullable;
+
+public class EnigmaUtil {
+	public static @Nullable String[] serializeEntry(Entry<?> entry, boolean removeNone, String... extraFields) {
+		String[] data = null;
+
+		if (entry instanceof FieldEntry) {
+			data = new String[4 + extraFields.length];
+			data[0] = "FIELD";
+			data[1] = entry.getContainingClass().getFullName();
+			data[2] = ((FieldEntry) entry).getDesc().toString();
+			data[3] = entry.getName();
+
+			if (removeNone) {
+				data[1] = StitchUtil.NONE_PREFIX_REMOVER.map(data[1]);
+				data[2] = StitchUtil.NONE_PREFIX_REMOVER.mapDesc(data[2]);
+			}
+		} else if (entry instanceof MethodEntry) {
+			data = new String[4 + extraFields.length];
+			data[0] = "METHOD";
+			data[1] = entry.getContainingClass().getFullName();
+			data[2] = ((MethodEntry) entry).getDesc().toString();
+			data[3] = entry.getName();
+
+			if (removeNone) {
+				data[1] = StitchUtil.NONE_PREFIX_REMOVER.map(data[1]);
+				data[2] = StitchUtil.NONE_PREFIX_REMOVER.mapMethodDesc(data[2]);
+			}
+		} else if (entry instanceof ClassEntry) {
+			data = new String[2 + extraFields.length];
+			data[0] = "CLASS";
+			data[1] = ((ClassEntry) entry).getFullName();
+
+			if (removeNone) {
+				data[1] = StitchUtil.NONE_PREFIX_REMOVER.map(data[1]);
+			}
+		}
+
+		if (data != null) {
+			System.arraycopy(extraFields, 0, data, data.length - extraFields.length, extraFields.length);
+		}
+
+		return data;
+	}
+
+	public static @Nullable Entry<?> deserializeEntry(String[] data) {
+		if (data.length > 0) {
+			if (data[0].equals("FIELD") && data.length >= 4) {
+				return new FieldEntry(new ClassEntry(data[1]), data[3], new TypeDescriptor(data[2]));
+			} else if (data[0].equals("METHOD") && data.length >= 4) {
+				return new MethodEntry(new ClassEntry(data[1]), data[3], new MethodDescriptor(data[2]));
+			} else if (data[0].equals("CLASS") && data.length >= 2) {
+				return new ClassEntry(data[1]);
+			}
+		}
+
+		return null;
+	}
+}

--- a/src/main/java/net/fabricmc/stitch/enigma/EnigmaUtil.java
+++ b/src/main/java/net/fabricmc/stitch/enigma/EnigmaUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2017, 2018 FabricMC
+ * Copyright (c) 2016, 2017, 2018 Adrian Siekierka
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/fabricmc/stitch/util/StitchUtil.java
+++ b/src/main/java/net/fabricmc/stitch/util/StitchUtil.java
@@ -16,11 +16,14 @@
 
 package net.fabricmc.stitch.util;
 
+import com.google.common.base.Joiner;
+import com.google.common.base.Splitter;
+import org.objectweb.asm.commons.Remapper;
+
 import java.io.File;
 import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
-import java.net.URLEncoder;
 import java.nio.file.FileSystem;
 import java.nio.file.FileSystemAlreadyExistsException;
 import java.nio.file.FileSystems;
@@ -54,6 +57,19 @@ public final class StitchUtil {
 
     private static final Map<String, String> jfsArgsCreate = new HashMap<>();
     private static final Map<String, String> jfsArgsEmpty = new HashMap<>();
+
+    public static final Remapper NONE_PREFIX_REMOVER = new Remapper() {
+        @Override
+        public String map(String name) {
+            if (name.startsWith("none/")) {
+                return name.substring(5);
+            } else {
+                return name;
+            }
+        }
+    };
+    public static final Joiner TAB_JOINER = Joiner.on('\t');
+    public static final Splitter TAB_SPLITTER = Splitter.on('\t');
 
     static {
         jfsArgsCreate.put("create", "true");


### PR DESCRIPTION
Closes FabricMC/weave#2

In the future, we just need to update stitch when yarn needs. Weave can die in a fire pretty much.

It appears that weave initially was dedicated to enigma compared to stitch, but since weave has much framework duplicated with stitch and stitch has an enigma plugin, it's worthy to merge these two.

Signed-off-by: liach <liach@users.noreply.github.com>