### PR TITLE
Change enum field automapping to use enum field detection instead

### DIFF
--- a/src/main/java/net/fabricmc/stitch/util/FieldNameFinder.java
+++ b/src/main/java/net/fabricmc/stitch/util/FieldNameFinder.java
@@ -17,184 +17,174 @@
 package net.fabricmc.stitch.util;
 
 import net.fabricmc.mappings.EntryTriple;
-import net.fabricmc.stitch.commands.CommandProposeFieldNames;
-import net.fabricmc.stitch.merge.JarMerger;
 import org.objectweb.asm.ClassReader;
-import org.objectweb.asm.ClassVisitor;
-import org.objectweb.asm.MethodVisitor;
 import org.objectweb.asm.Opcodes;
-import org.objectweb.asm.tree.*;
-import org.objectweb.asm.tree.analysis.*;
+import org.objectweb.asm.tree.AbstractInsnNode;
+import org.objectweb.asm.tree.FieldInsnNode;
+import org.objectweb.asm.tree.InsnList;
+import org.objectweb.asm.tree.LdcInsnNode;
+import org.objectweb.asm.tree.MethodInsnNode;
+import org.objectweb.asm.tree.MethodNode;
+import org.objectweb.asm.tree.analysis.Analyzer;
+import org.objectweb.asm.tree.analysis.Frame;
+import org.objectweb.asm.tree.analysis.SourceInterpreter;
+import org.objectweb.asm.tree.analysis.SourceValue;
 
-import java.io.*;
-import java.util.*;
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.FileInputStream;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
 import java.util.jar.JarEntry;
 import java.util.jar.JarInputStream;
 
 public class FieldNameFinder {
-    private class VClass extends ClassVisitor {
-        private final List<MethodNode> nodes = new ArrayList<>();
-
-        public VClass(int api) {
-            super(api);
-        }
-
-        @Override
-        public MethodVisitor visitMethod(
-                final int access,
-                final String name,
-                final String descriptor,
-                final String signature,
-                final String[] exceptions) {
-            if ("<clinit>".equals(name)) {
-                MethodNode node = new MethodNode(api, access, name, descriptor, signature, exceptions);
-                nodes.add(node);
-                return node;
-            } else {
-                return super.visitMethod(access, name, descriptor, signature, exceptions);
-            }
-        }
-    }
 
 	public Map<EntryTriple, String> findNames(Iterable<byte[]> classes) throws Exception {
-    	Map<String, List<MethodNode>> methods = new HashMap<>();
+		Map<String, List<MethodNode>> methods = new HashMap<>();
+		Map<String, Set<String>> enumFields = new HashMap<>();
 
 		for (byte[] data : classes) {
 			ClassReader reader = new ClassReader(data);
-			String owner = reader.getClassName();
-			VClass vClass = new VClass(Opcodes.ASM7);
+			NameFinderVisitor vClass = new NameFinderVisitor(Opcodes.ASM7, enumFields, methods);
 			reader.accept(vClass, ClassReader.SKIP_FRAMES);
-			methods.put(owner, vClass.nodes);
 		}
 
-    	return findNames(methods);
+		return findNames(enumFields, methods);
 	}
 
-    public Map<EntryTriple, String> findNames(Map<String, List<MethodNode>> classes) throws Exception {
-        Analyzer<SourceValue> analyzer = new Analyzer<>(new SourceInterpreter());
-        Map<EntryTriple, String> fieldNames = new HashMap<>();
-        Map<String, Set<String>> fieldNamesUsed = new HashMap<>();
-        Map<String, Set<String>> fieldNamesDuplicate = new HashMap<>();
+	public Map<EntryTriple, String> findNames(Map<String, Set<String>> allEnumFields, Map<String, List<MethodNode>> classes) throws Exception {
+		Analyzer<SourceValue> analyzer = new Analyzer<>(new SourceInterpreter());
+		Map<EntryTriple, String> fieldNames = new HashMap<>();
+		Map<String, Set<String>> fieldNamesUsed = new HashMap<>();
+		Map<String, Set<String>> fieldNamesDuplicate = new HashMap<>();
 
-        for (Map.Entry<String, List<MethodNode>> entry : classes.entrySet()) {
-        	String owner = entry.getKey();
-            for (MethodNode mn : entry.getValue()) {
-                Frame<SourceValue>[] frames = analyzer.analyze(owner, mn);
+		for (Map.Entry<String, List<MethodNode>> entry : classes.entrySet()) {
+			String owner = entry.getKey();
+			Set<String> enumFields = allEnumFields.getOrDefault(owner, Collections.emptySet());
+			for (MethodNode mn : entry.getValue()) {
+				Frame<SourceValue>[] frames = analyzer.analyze(owner, mn);
 
-                InsnList instrs = mn.instructions;
-                for (int i = 1; i < instrs.size(); i++) {
-                    AbstractInsnNode instr1 = instrs.get(i - 1);
-                    AbstractInsnNode instr2 = instrs.get(i);
-                    String s = null;
+				InsnList instrs = mn.instructions;
+				for (int i = 1; i < instrs.size(); i++) {
+					AbstractInsnNode instr1 = instrs.get(i - 1);
+					AbstractInsnNode instr2 = instrs.get(i);
+					String s = null;
 
-                    if (instr2.getOpcode() == Opcodes.PUTSTATIC && ((FieldInsnNode) instr2).owner.equals(owner)
-                            && instr1 instanceof MethodInsnNode && ((MethodInsnNode) instr1).owner.equals(owner)
-                            && (instr1.getOpcode() == Opcodes.INVOKESTATIC || (instr1.getOpcode() == Opcodes.INVOKESPECIAL && "<init>".equals(((MethodInsnNode) instr1).name)))) {
+					if (instr2.getOpcode() == Opcodes.PUTSTATIC && ((FieldInsnNode) instr2).owner.equals(owner)
+							&& (instr1 instanceof MethodInsnNode && ((MethodInsnNode) instr1).owner.equals(owner) || enumFields.contains(((FieldInsnNode) instr2).desc + ((FieldInsnNode) instr2).name))
+							&& (instr1.getOpcode() == Opcodes.INVOKESTATIC || (instr1.getOpcode() == Opcodes.INVOKESPECIAL && "<init>".equals(((MethodInsnNode) instr1).name)))) {
 
-                        for (int j = 0; j < frames[i - 1].getStackSize(); j++) {
-                            SourceValue sv = frames[i - 1].getStack(j);
-                            for (AbstractInsnNode ci : sv.insns) {
-                                if (ci instanceof LdcInsnNode && ((LdcInsnNode) ci).cst instanceof String) {
-                                    //if (s == null || !s.equals(((LdcInsnNode) ci).cst)) {
-                                    if (s == null) {
-                                        s = (String) (((LdcInsnNode) ci).cst);
-                                        // stringsFound++;
-                                    }
-                                }
-                            }
-                        }
-                    }
+						for (int j = 0; j < frames[i - 1].getStackSize(); j++) {
+							SourceValue sv = frames[i - 1].getStack(j);
+							for (AbstractInsnNode ci : sv.insns) {
+								if (ci instanceof LdcInsnNode && ((LdcInsnNode) ci).cst instanceof String) {
+									//if (s == null || !s.equals(((LdcInsnNode) ci).cst)) {
+									if (s == null) {
+										s = (String) (((LdcInsnNode) ci).cst);
+										// stringsFound++;
+									}
+								}
+							}
+						}
+					}
 
-                    if (s != null) {
-                        if (s.contains(":")) {
-                            s = s.substring(s.indexOf(':') + 1);
-                        }
+					if (s != null) {
+						if (s.contains(":")) {
+							s = s.substring(s.indexOf(':') + 1);
+						}
 
-                        if (s.contains("/")) {
-                            int separator = s.indexOf('/');
-                            String sFirst = s.substring(0, separator);
-                            String sLast;
-                            if (s.contains(".") && s.indexOf('.') > separator) {
-                                sLast = s.substring(separator + 1, s.indexOf('.'));
-                            } else {
-                                sLast = s.substring(separator + 1);
-                            }
-                            if (sFirst.endsWith("s")) {
-                                sFirst = sFirst.substring(0, sFirst.length() - 1);
-                            }
-                            s = sLast + "_" + sFirst;
-                        }
+						if (s.contains("/")) {
+							int separator = s.indexOf('/');
+							String sFirst = s.substring(0, separator);
+							String sLast;
+							if (s.contains(".") && s.indexOf('.') > separator) {
+								sLast = s.substring(separator + 1, s.indexOf('.'));
+							} else {
+								sLast = s.substring(separator + 1);
+							}
+							if (sFirst.endsWith("s")) {
+								sFirst = sFirst.substring(0, sFirst.length() - 1);
+							}
+							s = sLast + "_" + sFirst;
+						}
 
-                        String oldS = s;
-                        boolean hasAlpha = false;
+						String oldS = s;
+						boolean hasAlpha = false;
 
-                        for (int j = 0; j < s.length(); j++) {
-                            char c = s.charAt(j);
+						for (int j = 0; j < s.length(); j++) {
+							char c = s.charAt(j);
 
-                            if ((c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z')) {
-                                hasAlpha = true;
-                            }
+							if ((c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z')) {
+								hasAlpha = true;
+							}
 
-                            if (!(c >= 'A' && c <= 'Z') && !(c >= 'a' && c <= 'z') && !(c >= '0' && c <= '9') && !(c == '_')) {
-                                s = s.substring(0, j) + "_" + s.substring(j + 1);
-                            } else if (j > 0 && Character.isUpperCase(s.charAt(j)) && Character.isLowerCase(s.charAt(j - 1))) {
-                                s = s.substring(0, j) + "_" + s.substring(j, j + 1).toLowerCase(Locale.ROOT) + s.substring(j + 1);
-                            }
-                        }
+							if (!(c >= 'A' && c <= 'Z') && !(c >= 'a' && c <= 'z') && !(c >= '0' && c <= '9') && !(c == '_')) {
+								s = s.substring(0, j) + "_" + s.substring(j + 1);
+							} else if (j > 0 && Character.isUpperCase(s.charAt(j)) && Character.isLowerCase(s.charAt(j - 1))) {
+								s = s.substring(0, j) + "_" + s.substring(j, j + 1).toLowerCase(Locale.ROOT) + s.substring(j + 1);
+							}
+						}
 
-                        if (hasAlpha) {
-                            s = s.toUpperCase(Locale.ROOT);
+						if (hasAlpha) {
+							s = s.toUpperCase(Locale.ROOT);
 
-                            Set<String> usedNames = fieldNamesUsed.computeIfAbsent(((FieldInsnNode) instr2).owner, (a) -> new HashSet<>());
-                            Set<String> usedNamesDuplicate = fieldNamesDuplicate.computeIfAbsent(((FieldInsnNode) instr2).owner, (a) -> new HashSet<>());
+							Set<String> usedNames = fieldNamesUsed.computeIfAbsent(((FieldInsnNode) instr2).owner, (a) -> new HashSet<>());
+							Set<String> usedNamesDuplicate = fieldNamesDuplicate.computeIfAbsent(((FieldInsnNode) instr2).owner, (a) -> new HashSet<>());
 
-                            if (!usedNamesDuplicate.contains(s)) {
-                                if (!usedNames.add(s)) {
-                                    System.err.println("Warning: Duplicate key: " + s + " (" + oldS + ")!");
-                                    usedNamesDuplicate.add(s);
-                                    usedNames.remove(s);
-                                }
-                            }
+							if (!usedNamesDuplicate.contains(s)) {
+								if (!usedNames.add(s)) {
+									System.err.println("Warning: Duplicate key: " + s + " (" + oldS + ")!");
+									usedNamesDuplicate.add(s);
+									usedNames.remove(s);
+								}
+							}
 
-                            if (usedNames.contains(s)) {
-                                fieldNames.put(new EntryTriple(((FieldInsnNode) instr2).owner, ((FieldInsnNode) instr2).name, ((FieldInsnNode) instr2).desc), s);
-                            }
-                        }
-                    }
-                }
-            }
-        }
+							if (usedNames.contains(s)) {
+								fieldNames.put(new EntryTriple(((FieldInsnNode) instr2).owner, ((FieldInsnNode) instr2).name, ((FieldInsnNode) instr2).desc), s);
+							}
+						}
+					}
+				}
+			}
+		}
 
-        return fieldNames;
-    }
+		return fieldNames;
+	}
 
-    public Map<EntryTriple, String> findNames(File file) {
-        List<byte[]> byteArrays = new ArrayList<>();
+	public Map<EntryTriple, String> findNames(File file) {
+		List<byte[]> byteArrays = new ArrayList<>();
 
-        try {
-            try (FileInputStream fis = new FileInputStream(file);
-                 JarInputStream jis = new JarInputStream(fis)) {
-                byte[] buffer = new byte[32768];
-                JarEntry entry;
+		try {
+			try (FileInputStream fis = new FileInputStream(file);
+				 JarInputStream jis = new JarInputStream(fis)) {
+				byte[] buffer = new byte[32768];
+				JarEntry entry;
 
-                while ((entry = jis.getNextJarEntry()) != null) {
-                    if (!entry.getName().endsWith(".class")) {
-                        continue;
-                    }
+				while ((entry = jis.getNextJarEntry()) != null) {
+					if (!entry.getName().endsWith(".class")) {
+						continue;
+					}
 
-                    ByteArrayOutputStream stream = new ByteArrayOutputStream();
-                    int l;
-                    while ((l = jis.read(buffer, 0, buffer.length)) > 0) {
-                        stream.write(buffer, 0, l);
-                    }
+					ByteArrayOutputStream stream = new ByteArrayOutputStream();
+					int l;
+					while ((l = jis.read(buffer, 0, buffer.length)) > 0) {
+						stream.write(buffer, 0, l);
+					}
 
-                    byteArrays.add(stream.toByteArray());
-                }
-            }
+					byteArrays.add(stream.toByteArray());
+				}
+			}
 
-            return findNames(byteArrays);
-        } catch (Exception e) {
-            throw new RuntimeException(e);
-        }
-    }
+			return findNames(byteArrays);
+		} catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
 }

--- a/src/main/java/net/fabricmc/stitch/util/NameFinderVisitor.java
+++ b/src/main/java/net/fabricmc/stitch/util/NameFinderVisitor.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 Adrian Siekierka
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.fabricmc.stitch.util;
+
+import org.objectweb.asm.ClassVisitor;
+import org.objectweb.asm.FieldVisitor;
+import org.objectweb.asm.MethodVisitor;
+import org.objectweb.asm.Opcodes;
+import org.objectweb.asm.tree.MethodNode;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+public class NameFinderVisitor extends ClassVisitor {
+	private String owner;
+	private final Map<String, Set<String>> allEnumFields;
+	private final Map<String, List<MethodNode>> allMethods;
+
+	public NameFinderVisitor(int api, Map<String, Set<String>> allEnumFields, Map<String, List<MethodNode>> allMethods) {
+		super(api);
+		this.allMethods = allMethods;
+		this.allEnumFields = allEnumFields;
+	}
+
+	@Override
+	public void visit(int version, int access, String name, String signature, String superName, String[] interfaces) {
+		this.owner = name;
+		super.visit(version, access, name, signature, superName, interfaces);
+	}
+
+	@Override
+	public FieldVisitor visitField(int access, String name, String descriptor, String signature, Object value) {
+		if ((access & Opcodes.ACC_ENUM) != 0) {
+			if (!allEnumFields.computeIfAbsent(owner, s -> new HashSet<>()).add(descriptor + name)) {
+				throw new IllegalArgumentException("Found two enum fields with the same name \"" + name + "\"!");
+			}
+		}
+		return super.visitField(access, name, descriptor, signature, value);
+	}
+
+	@Override
+	public MethodVisitor visitMethod(
+			final int access,
+			final String name,
+			final String descriptor,
+			final String signature,
+			final String[] exceptions) {
+		if ("<clinit>".equals(name)) {
+			MethodNode node = new MethodNode(api, access, name, descriptor, signature, exceptions);
+			allMethods.computeIfAbsent(owner, s -> new ArrayList<>()).add(node);
+			return node;
+		} else {
+			return super.visitMethod(access, name, descriptor, signature, exceptions);
+		}
+	}
+}


### PR DESCRIPTION
Now infers for anonymous enclosed enum subclasses like the one found in Gl State Manager.

With new stitich:
<img width="575" alt="infer subclass" src="https://user-images.githubusercontent.com/7806504/60020609-efa68400-96c2-11e9-9990-35f8788ab48e.PNG">

With old stitich:
![image](https://user-images.githubusercontent.com/7806504/60021357-73ad3b80-96c4-11e9-9e7c-3c007431326c.png)

Signed-off-by: liach <liach@users.noreply.github.com>