### PR TITLE
Fix lambda variable names conflicting with names in the enclosing method

### DIFF
--- a/src/main/java/net/fabricmc/stitch/util/SnowmanClassVisitor.java
+++ b/src/main/java/net/fabricmc/stitch/util/SnowmanClassVisitor.java
@@ -21,6 +21,8 @@ import org.objectweb.asm.Label;
 import org.objectweb.asm.MethodVisitor;
 
 public class SnowmanClassVisitor extends ClassVisitor {
+	private int localCounter = 0;
+
 	public static class SnowmanMethodVisitor extends MethodVisitor {
 		public SnowmanMethodVisitor(int api, MethodVisitor methodVisitor) {
 			super(api, methodVisitor);
@@ -45,7 +47,7 @@ public class SnowmanClassVisitor extends ClassVisitor {
 				final int index) {
 			String newName = name;
 			if (name != null && name.startsWith("\u2603")) {
-				newName = "lvt" + index;
+				newName = "local_" + localCounter++;
 			}
 			super.visitLocalVariable(newName, descriptor, signature, start, end, index);
 		}

--- a/src/main/java/net/fabricmc/stitch/util/SnowmanClassVisitor.java
+++ b/src/main/java/net/fabricmc/stitch/util/SnowmanClassVisitor.java
@@ -47,7 +47,7 @@ public class SnowmanClassVisitor extends ClassVisitor {
 				final int index) {
 			String newName = name;
 			if (name != null && name.startsWith("\u2603")) {
-				newName = "local_" + localCounter++;
+				newName = "var" + localCounter++;
 			}
 			super.visitLocalVariable(newName, descriptor, signature, start, end, index);
 		}


### PR DESCRIPTION
Currently stitch renames local variables based on their index, which causes conflicts with variables inside a lambda function (which is a separate synthetic method) in the decompiled source. Instead, give each local in the class a unique name.