### PR TITLE
Allow using other target namespaces and obf patterns in updateIntermediary

### DIFF
--- a/src/main/java/net/fabricmc/stitch/commands/CommandUpdateIntermediary.java
+++ b/src/main/java/net/fabricmc/stitch/commands/CommandUpdateIntermediary.java
@@ -21,6 +21,7 @@ import net.fabricmc.stitch.representation.*;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.Locale;
 
 public class CommandUpdateIntermediary extends Command {
     public CommandUpdateIntermediary() {
@@ -29,12 +30,12 @@ public class CommandUpdateIntermediary extends Command {
 
     @Override
     public String getHelpString() {
-        return "<old-jar> <new-jar> <old-mapping-file> <new-mapping-file> <match-file>";
+        return "<old-jar> <new-jar> <old-mapping-file> <new-mapping-file> <match-file> [-t|--target-namespace <namespace>] [-p|--obfuscation-pattern <regex pattern>]";
     }
 
     @Override
     public boolean isArgumentCountValid(int count) {
-        return count == 5;
+        return count >= 5;
     }
 
     @Override
@@ -58,6 +59,27 @@ public class CommandUpdateIntermediary extends Command {
         }
 
         GenState state = new GenState();
+        boolean clearedPatterns = false;
+
+        for (int i = 5; i < args.length; i++) {
+            switch (args[i].toLowerCase(Locale.ROOT)) {
+                case "-t":
+                case "--target-namespace":
+                    state.setTargetNamespace(args[i + 1]);
+                    i++;
+                    break;
+                case "-p":
+                case "--obfuscation-pattern":
+                    if (!clearedPatterns)
+                        state.clearObfuscatedPatterns();
+                    clearedPatterns = true;
+
+                    state.addObfuscatedPattern(args[i + 1]);
+                    i++;
+                    break;
+            }
+        }
+
         System.err.println("Loading remapping files...");
         state.prepareUpdate(new File(args[2]), new File(args[4]));
 


### PR DESCRIPTION
This is implemented with basically the same code as in generateIntermediary. This is useful in cases where you have generated intermediaries with a different package name, but need to update them without classes going to `net.minecraft`.