### PR TITLE
Move environment annotations from fabric-loader into a separate subproject

### DIFF
--- a/annotations/build.gradle
+++ b/annotations/build.gradle
@@ -1,0 +1,5 @@
+
+java {
+    withSourcesJar()
+    withJavadocJar()
+}

--- a/annotations/src/main/java/net/fabricmc/stitch/annotation/EnvType.java
+++ b/annotations/src/main/java/net/fabricmc/stitch/annotation/EnvType.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2016 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.fabricmc.stitch.annotation;
+
+/**
+ * Represents a type of environment.
+ *
+ * <p>A type of environment is a jar file in a <i>Minecraft</i> version's json file's {@code download}
+ * subsection, including the {@code client.jar} and the {@code server.jar}.</p>
+ *
+ * @see Environment
+ * @see EnvironmentInterface
+ */
+public enum EnvType {
+	/**
+	 * Represents the client environment type, in which the {@code client.jar} for a
+	 * <i>Minecraft</i> version is the main game jar.
+	 *
+	 * <p>A client environment type has all client logic (client rendering and integrated
+	 * server logic), the data generator logic, and dedicated server logic. It encompasses
+	 * everything that is available on the {@linkplain #SERVER server environment type}.</p>
+	 */
+	CLIENT,
+	/**
+	 * Represents the server environment type, in which the {@code server.jar} for a
+	 * <i>Minecraft</i> version is the main game jar.
+	 *
+	 * <p>A server environment type has the dedicated server lgoic and data generator
+	 * logic, which are all included in the {@linkplain #CLIENT client environment type}.
+	 * However, the server environment type has its libraries embedded compared to the
+	 * client.</p>
+	 */
+	SERVER
+}

--- a/annotations/src/main/java/net/fabricmc/stitch/annotation/Environment.java
+++ b/annotations/src/main/java/net/fabricmc/stitch/annotation/Environment.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2016 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.fabricmc.stitch.annotation;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Applied to declare that the annotated element is present only in the specified environment.
+ *
+ * <p>Use with caution, as Fabric-loader will remove the annotated element in a mismatched environment!</p>
+ *
+ * <p>When the annotated element is removed, bytecode associated with the element will not be removed.
+ * For example, if a field is removed, its initializer code will not, and will cause an error on execution.</p>
+ *
+ * <p>If an overriding method has this annotation and its overridden method doesn't,
+ * unexpected behavior may happen. If an overridden method has this annotation
+ * while the overriding method doesn't, it is safe, but the method can be used from
+ * the overridden class only in the specified environment.</p>
+ *
+ * @see EnvironmentInterface
+ */
+@Retention(RetentionPolicy.CLASS)
+@Target({ElementType.TYPE, ElementType.METHOD, ElementType.FIELD, ElementType.CONSTRUCTOR})
+@Documented
+public @interface Environment {
+	/**
+	 * The environment type that the annotated element is only present in.
+	 *
+	 * @return the expected environment type
+	 */
+	EnvType value();
+}

--- a/annotations/src/main/java/net/fabricmc/stitch/annotation/EnvironmentInterface.java
+++ b/annotations/src/main/java/net/fabricmc/stitch/annotation/EnvironmentInterface.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2016 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.fabricmc.stitch.annotation;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Repeatable;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Applied to declare that a class implements an interface only in the specified environment.
+ *
+ * <p>Use with caution, as Fabric-loader will remove the interface from {@code implements} declaration
+ * of the class in a mismatched environment!</p>
+ *
+ * <p>Implemented methods are not removed. To remove implemented methods, use {@link Environment}.</p>
+ *
+ * @see Environment
+ */
+@Retention(RetentionPolicy.CLASS)
+@Repeatable(EnvironmentInterfaces.class)
+@Target(ElementType.TYPE)
+@Documented
+public @interface EnvironmentInterface {
+	/**
+	 * The environment type that the specific interface is only implemented in.
+	 *
+	 * @return the environment type
+	 */
+	EnvType value();
+
+	/**
+	 * Returns the interface class.
+	 *
+	 * @return the interface that is implemented in the environment
+	 */
+	Class<?> itf();
+}

--- a/annotations/src/main/java/net/fabricmc/stitch/annotation/EnvironmentInterfaces.java
+++ b/annotations/src/main/java/net/fabricmc/stitch/annotation/EnvironmentInterfaces.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2016 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.fabricmc.stitch.annotation;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * A container of multiple {@link EnvironmentInterface} annotations on a class, often defined implicitly.
+ */
+@Retention(RetentionPolicy.CLASS)
+@Target(ElementType.TYPE)
+@Documented
+public @interface EnvironmentInterfaces {
+	/**
+	 * Returns the {@link EnvironmentInterface} annotations it holds.
+	 *
+	 * @return the contained annotations
+	 */
+	EnvironmentInterface[] value();
+}

--- a/build.gradle
+++ b/build.gradle
@@ -1,8 +1,3 @@
-apply plugin: 'java'
-apply plugin: 'eclipse'
-apply plugin: 'idea'
-apply plugin: 'maven-publish'
-
 buildscript {
 	repositories {
 		maven {
@@ -12,21 +7,57 @@ buildscript {
 	}
 }
 
-sourceCompatibility = 1.8
+// Apply to stitch itself, and subprojects
 
-def ENV = System.getenv()
-version = version + "+" + (ENV.BUILD_NUMBER ? ("build." + ENV.BUILD_NUMBER) : "local")
+allprojects {
+	apply plugin: 'java'
+	apply plugin: 'eclipse'
+	apply plugin: 'idea'
+	apply plugin: 'maven-publish'
 
-group = 'net.fabricmc'
-archivesBaseName = project.name.toLowerCase()
+	sourceCompatibility = 1.8
 
-repositories {
-	mavenCentral()
-	maven {
-		name = 'Fabric'
-		url = 'https://maven.fabricmc.net/'
+	def ENV = System.getenv()
+	version = version + "+" + (ENV.BUILD_NUMBER ? ("build." + ENV.BUILD_NUMBER) : "local")
+
+	group = 'net.fabricmc'
+	archivesBaseName = project.name.toLowerCase()
+
+	repositories {
+		mavenCentral()
+		maven {
+			name = 'Fabric'
+			url = 'https://maven.fabricmc.net/'
+		}
+	}
+
+	publishing {
+		publications {
+			mavenJava(MavenPublication) {
+				from components.java
+			}
+		}
+
+		// select the repositories you want to publish to
+		repositories {
+			if (project.hasProperty('mavenPass')) {
+				maven {
+					url = "http://mavenupload.modmuss50.me/"
+					credentials {
+						username = "buildslave"
+						password = project.getProperty('mavenPass')
+					}
+				}
+			}
+		}
+	}
+
+	test {
+		useJUnitPlatform()
 	}
 }
+
+// Just stitch
 
 configurations {
 	ship
@@ -79,29 +110,8 @@ artifacts {
 	archives allJar
 }
 
-
-publishing {
-	publications {
-		mavenJava(MavenPublication) {
-			from components.java
-			artifact(allJar)
-		}
-	}
-
-	// select the repositories you want to publish to
-	repositories {
-		if (project.hasProperty('mavenPass')) {
-			maven {
-				url = "http://mavenupload.modmuss50.me/"
-				credentials {
-					username = "buildslave"
-					password = project.getProperty('mavenPass')
-				}
-			}
-		}
-	}
+publishing.publications.mavenJava {
+	artifact(allJar)
 }
 
-test {
-	useJUnitPlatform()
-}
+

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,2 +1,5 @@
 rootProject.name = 'stitch'
 
+include("annotations")
+findProject(":annotations").name = "stitch-annotations"
+

--- a/src/main/java/net/fabricmc/stitch/merge/JarMerger.java
+++ b/src/main/java/net/fabricmc/stitch/merge/JarMerger.java
@@ -16,6 +16,7 @@
 
 package net.fabricmc.stitch.merge;
 
+import net.fabricmc.stitch.util.EnvironmentAnnotations;
 import net.fabricmc.stitch.util.SnowmanClassVisitor;
 import net.fabricmc.stitch.util.StitchUtil;
 import net.fabricmc.stitch.util.SyntheticParameterClassVisitor;
@@ -177,12 +178,12 @@ public class JarMerger implements AutoCloseable {
                     }
                 }
             } else if ((result = entry1) != null) {
-                side = "CLIENT";
+                side = EnvironmentAnnotations.ENV_CLIENT;
             } else if ((result = entry2) != null) {
-                side = "SERVER";
+                side = EnvironmentAnnotations.ENV_SERVER;
             }
 
-            if (isClass && !isMinecraft && "SERVER".equals(side)) {
+            if (isClass && !isMinecraft && EnvironmentAnnotations.ENV_SERVER.equals(side)) {
                 // Server bundles libraries, client doesn't - skip them
                 return null;
             }

--- a/src/main/java/net/fabricmc/stitch/util/EnvironmentAnnotations.java
+++ b/src/main/java/net/fabricmc/stitch/util/EnvironmentAnnotations.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.fabricmc.stitch.util;
+
+/**
+ * Annotations used to declare a sided environment.
+ */
+public final class EnvironmentAnnotations {
+    public static final String ENV_SERVER = "SERVER";
+    public static final String ENV_CLIENT = "CLIENT";
+
+    private static String stitchAnnotation(final String name) {
+        return "Lnet/fabricmc/stitch/annotation/" + name + ";";
+    }
+
+    public static final String SIDE_DESCRIPTOR = stitchAnnotation("EnvType");
+    public static final String ITF_DESCRIPTOR = stitchAnnotation("EnvironmentInterface");
+    public static final String ITF_LIST_DESCRIPTOR = stitchAnnotation("EnvironmentInterfaces");
+    public static final String SIDED_DESCRIPTOR = stitchAnnotation("Environment");
+
+    private EnvironmentAnnotations() {
+    }
+}


### PR DESCRIPTION
**Stitch** | [Loader](https://github.com/FabricMC/fabric-loader/pull/351) | [Loom](https://github.com/FabricMC/fabric-loom/pull/316)

Stitch uses these annotations when merging, so owning the annotations means that there is no longer an implicit compile-time dependency on loader for merged jars.

Migrating is a bit particular to make sure no mods are broken, and to make sure that developers don't get deprecation warnings before support for the new annotations is widespread among users.

The first step is updating stitch -- this will produce a merged artifact with the new annotations as other projects update.

`yarn` can be updated right away -- that's just a version bump (and ideally linking to published JD for `stitch-annotations`)

Loader can be updated to support both annotations simultaneously, without deprecating the old ones -- see the linked PR. This will allow older mods to continue functioning through the deprecation period.

Then, loom 0.6 can adopt the new `stitch` version, and once loom 0.6 becomes the recommended version the old annotations can be deprecated in loader.

The only concern with migration is existing cached jars -- loom won't automatically regenerate them, so once the old annotations have been removed, mod developers going back to work on MC versions cached before the stitch change while using newer Loom may have to refresh their caches. I don't expect that to be an issue that often though, since devs will probably just use older Loom with their old versions of MC.