### PR TITLE
Rework the handling of inner classes.

### DIFF
--- a/src/main/java/net/fabricmc/stitch/representation/ClassStorage.java
+++ b/src/main/java/net/fabricmc/stitch/representation/ClassStorage.java
@@ -17,5 +17,5 @@
 package net.fabricmc.stitch.representation;
 
 public interface ClassStorage {
-    JarClassEntry getClass(String name, boolean create);
+    JarClassEntry getClass(String name, JarClassEntry.Populator populator);
 }


### PR DESCRIPTION
By convention inner class names are of the form `com/example/Example$InnerName`, which encodes both the outer class' name, as well as the inner class' inner name, but this is not required by the JVM spec. However, Stitch fully relies on classes' names following this convention, and if they do not, Stitch treats them as top level classes, even if the appropriate attributes are present. Similarly, if the inner and outer class attributes are not present, but the classes' names suggest the classes are nested, Stitch will treat them as such.

This PR fixes these issues by looking for the inner and outer class attributes to retrieve the enclosing class and inner name of a class, instead of relying on class names following the standard `$` convention.

I ended up removing a significant part of `JarReader`, as it appeared to be dead code and it made it easier to add the new necessary parts. I'm just mentioning it here 'cause it's a fairly large change that isn't strictly related to the PR.